### PR TITLE
generating a complete summary for deployments

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -660,7 +660,7 @@ class Api {
             n(null, results)
           })
         } else if (NODE_TYPES.indexOf(node) !== -1) {
-          console.log('filtering ', node)
+          // console.log('filtering ', node)
           filter(Object.keys(this._config.services), (service, next) => {
             if (this._config.services[service].environment && this._config.services[service].environment.type) {
               next(null, (node === `${this._config.services[service].environment.type}s`))

--- a/src/cli/lpth.js
+++ b/src/cli/lpth.js
@@ -28,19 +28,8 @@ program
     // console.log(name, lpnode, env.type)
     parseDockerCompose(name, (err, experiment) => {
       if (err) throw err
-      let servicesNames = Object.keys(experiment.services)
-      let num = lpnode.split('_')[1]
       let port = null
-      let serviceName = null
-      if (lpnode.startsWith('b_')) {
-        serviceName = `broadcaster_${num}`
-      } else if (lpnode.startsWith('b_')) {
-        serviceName = `transcoder_${num}`
-      } else if (lpnode.startsWith('o_')) {
-        serviceName = `orchestrator_${num}`
-      } else {
-        serviceName = lpnode
-      }
+      let serviceName = lpnode
       // console.log('service name: ', serviceName)
       if (experiment.services[serviceName]) {
         switch (env.type) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,9 +8,16 @@ async function prettyPrintDeploymentInfo(parsedCompose) {
   const api = new Api(parsedCompose)
   const oPorts = await api.getPortsArray(['orchestrators'])
   const bPorts = await api.getPortsArray(['broadcasters'])
+  const tPorts = await api.getPortsArray(['transcoders'])
   const c = chalk.cyan
   console.log('==================================================================================')
   for (let po of oPorts) {
+    const ip = parsedCompose.isLocal ? 'localhost' : await Swarm.getPublicIPOfService(parsedCompose, po.name)
+    console.log(`===== ${chalk.green(po.name)}:`)
+    console.log(`./livepeer_cli -host ${ip} -http ${po['7935']}`)
+  }
+
+  for (let po of tPorts) {
     const ip = parsedCompose.isLocal ? 'localhost' : await Swarm.getPublicIPOfService(parsedCompose, po.name)
     console.log(`===== ${chalk.green(po.name)}:`)
     console.log(`./livepeer_cli -host ${ip} -http ${po['7935']}`)


### PR DESCRIPTION
this adds transcoders to deployment info, plus a ports cli fix
to generate a summary deployment file, simply run 
```bash
$ ./test-harness info <deployment_name> > my_summary_file
```
fixes issue #31 