### PR TITLE
fundDepositAndReserve instead of fundAndApproveSigners

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -456,8 +456,13 @@ class Api {
 
   // tickerbroker
   fundAndApproveSigners (nodes, depositAmountInWei, penaltyEscrowAmount, cb) {
+    console.log('WARNING: fundAndApproveSigners has been changed to fundDepositAndReserve, please use fundDepositAndReserve')
+    this.fundDepositAndReserve(nodes, depositAmountInWei, penaltyEscrowAmount, cb)
+  }
+
+  fundDepositAndReserve (nodes, depositAmountInWei, reserveAmount, cb) {
     return new Promise((resolve, reject) => {
-      let endpoint = `fundAndApproveSigners`
+      let endpoint = `fundDepositAndReserve`
       if (!nodes) {
         const e = new Error(`nodes array is required`)
         reject(e)
@@ -473,7 +478,7 @@ class Api {
 
       let params = {
         depositAmount: depositAmountInWei,
-        penaltyEscrowAmount: penaltyEscrowAmount
+        reserveAmount: reserveAmount
       }
 
       this._getPortsArray(nodes, (err, ports) => {

--- a/src/index.js
+++ b/src/index.js
@@ -414,9 +414,9 @@ class TestHarness {
         break
       }
       console.log('Depositing....')
-      // await this.api.fundAndApproveSigners(['all'], '5000000000', '500000000000000000')
-      await this.api.fundAndApproveSigners(['orchestrators'], '5000000000', '500000000000000000')
-      await this.api.fundAndApproveSigners(['broadcasters'], '5000000000', '500000000000000000')
+      // await this.api.fundDepositAndReserve(['all'], '5000000000', '500000000000000000')
+      await this.api.fundDepositAndReserve(['orchestrators'], '5000000000', '500000000000000000')
+      await this.api.fundDepositAndReserve(['broadcasters'], '5000000000', '500000000000000000')
       // check if deposit was successful
       tr = 0
       while (true) {


### PR DESCRIPTION
this changes `fundAndApproveSigners` to `fundDepositAndReserve` to match the newly added `go-livepeer` endpoint [here](https://github.com/livepeer/go-livepeer/blame/master/server/webserver.go#L1083)