### PR TITLE
Easier on chain default setup

### DIFF
--- a/examples/local.js
+++ b/examples/local.js
@@ -13,7 +13,6 @@ th.run({
   discordUserId: null, // id of Discord user to send alert from Prometheus to (use `Copy ID` on profile to get)
   standardSetup: true, // request token, register orchestartors, etc...
   name: 'test123',
-  livepeerBinaryPath: '../containers/lpnode/livepeer_linux/livepeer',
   email: null, // email to send alerts to
   blockchain: {
     // keep these to run a private testnet.
@@ -39,13 +38,13 @@ th.run({
       instances: 2,
       orchSecret: 'aapp',
       type: 'orchestrator',
-      flags: `-v 5 -initializeRound=true -gasPrice 20 -gasLimit 20000000 \
-      -currentManifest=true   -maxSessions 4  `
+      flags: `-v 5 -initializeRound=true \
+      -currentManifest=true -maxSessions 4`
     },
     broadcasters: {
       instances: 2,
       type: 'broadcaster',
-      flags: `-v 5 -gasPrice 20 -gasLimit 20000000  -currentManifest=true`
+      flags: `-v 5 -currentManifest=true`
     }
   }
 }, (err, experiment) => {

--- a/src/index.js
+++ b/src/index.js
@@ -455,8 +455,9 @@ Plese note now GCP logging is truned off by default and should be turned on expl
       const orchConf = {
         blockRewardCut: '10',
         feeShare: '5',
-        pricePerSegment: '1',
-        amount: '500'
+        amount: '500',
+        pricePerUnit: '1',
+        pixelsPerUnit: '1'
       }
 
       let tr = 0

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ Plese note now GCP logging is truned off by default and should be turned on expl
 
     if (parsedCompose.hasGeth) {
       await Promise.all(parsedCompose.addresses.map(address => {
-        return utils.fundAccount(address, '1', `${config.name}_geth_1`)
+        return utils.fundAccount(address, '10000', `${config.name}_geth_1`)
       }))
       console.log('funding secured!!')
     }
@@ -478,13 +478,10 @@ Plese note now GCP logging is truned off by default and should be turned on expl
         break
       }
       console.log('Depositing....')
-      // await this.api.fundDepositAndReserve(['all'], '5000000000', '500000000000000000')
-      // await this.api.fundDepositAndReserve(['orchestrators'], '1', '2')
-      // await this.api.fundDeposit(['broadcasters'], '1')
       console.log('Initialize round...', onames)
       await this.api.initializeRound([`${onames[0]}`])
       await wait(2000)
-      await this.api.fundDepositAndReserve(['broadcasters'], '2500000000', '1500000000')
+      await this.api.fundDepositAndReserve(['broadcasters'], '1000000000000000000000', '1000000000000000000000')
       // check if deposit was successful
       tr = 0
       while (true) {
@@ -504,18 +501,11 @@ Plese note now GCP logging is truned off by default and should be turned on expl
           break
         }
       }
-      await this.api.fundDepositAndReserve(['broadcasters'], '2500000000', '1500000000')
+
       console.log('Initialize round...', onames)
       await this.api.initializeRound([`${onames[0]}`])
       console.log('activating orchestrators...')
-      // await wait(2000)
-      // await this.api.activateOrchestrator(['orchestrators'], orchConf)
-      // bond
 
-      // await Promise.all(onames.map(n => this.restartService(n)))
-      // console.log(`restarted ${onames.length} orchestrators`)
-      // await Promise.all(bnames.map(n => this.restartService(n)))
-      // console.log(`restarted ${bnames.length} broadcasters`)
       await this.api.waitTillAlive(`${orchs.matchedNames[0]}_0`)
       let orchsList = await this.api.getOrchestratorsList(`${orchs.matchedNames[0]}_0`)
       console.log(`orchsList:`, orchsList)
@@ -684,7 +674,7 @@ Plese note now GCP logging is truned off by default and should be turned on expl
   fundAccountsList(config, addresses) {
     return new Promise((resolve, reject) => {
       eachLimit(addresses, 10, (address, cb) => {
-        utils.fundRemoteAccount(config, address, '1', `livepeer_geth`, cb)
+        utils.fundRemoteAccount(config, address, '10000', `livepeer_geth`, cb)
       }, (err) => {
         if (err) {
           reject(err)


### PR DESCRIPTION
This PR includes a few minor changes that should make it easier for an on-chain default setup to work right after deployment.

- 8d5fd71: Increase the default ETH funding for accounts and also increase the default deposit and reserve for broadcasters. This should ensure that deposit/reserve funds are not an issue when trying to test an on-chain payment workflow immediately after deployment. Also removed some commented out code that didn't seem needed anymore
- 440e7af: We need to specify `pricePerUnit` and `pricePerPixel` in the standard setup when activating an orchestrator due to livepeer/go-livepeer#993
- c62b57a: Update some flags and options (seems that using the `livepeerBinaryPath` option is no longer recommended and building a new image using `make localdocker` within the `go-livepeer` directory seems easier?) in the default local config (`examples/local.js`)