### PR TITLE
add faucet and tx-filler services in onchain mode

### DIFF
--- a/examples/local.js
+++ b/examples/local.js
@@ -18,7 +18,9 @@ th.run({
     // keep these to run a private testnet.
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF' //pm
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF', //pm
+    faucet: true,
+    txFiller: true
   },
   nodes: {
     streamers: {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,6 +46,14 @@ async function prettyPrintDeploymentInfo(parsedCompose) {
       console.log(`\nPrometheus (Grafana): ` + c(`http://${ip}:3001`))
     }
   }
+
+  if (parsedCompose.hasGeth) {
+    const ethRpc = parsedCompose.isLocal ? 'localhost' : await Swarm.getPublicIPOfService(parsedCompose, 'geth')
+    const ethFaucet = parsedCompose.isLocal ? 'localhost' : await Swarm.getPublicIPOfService(parsedCompose, 'gethFaucet')
+    console.log(`===== ${chalk.green('Blockchain')}:`)
+    console.log(`Geth JSON-RPC:  ${c(`http://${ethRpc}:8545`)}`)
+    console.log(`ETH Faucet:  ${c(`http://${ethFaucet}:3333`)}`)
+  }
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,6 @@ class TestHarness {
   /*
   onReady (config, cb) {
     if (config.local) {
-
     } else {
       const parsedCompose = parseComposeAndGetAddresses(config.name)
       eachLimit(parsedCompose.addresses, 5, (address, cb) => {

--- a/src/networkcreator.js
+++ b/src/networkcreator.js
@@ -556,6 +556,8 @@ class NetworkCreator extends EventEmitter {
     }
     output.gethFaucet = this.generateGethFaucet(volumes)
     output.gethTxFiller = this.generateGethTxFiller(volumes)
+    if (!output.gethFaucet) delete output.gethFaucet 
+    if (!output.gethTxFiller) delete output.gethTxFiller
     this.hasMetrics = this.config.metrics
     if (this.hasMetrics) {
       // output.prometheus = this.generatePrometheusService(outputFolder, volumes, configs)
@@ -1066,7 +1068,7 @@ class NetworkCreator extends EventEmitter {
 
   generateGethFaucet (volumes) {
     let faucetService = {
-      image: 'vergauwennico/livepeer-testnet:faucet',
+      image: 'livepeer/testnet-services:faucet',
       ports: [
         '3333:8080'
       ],
@@ -1094,7 +1096,7 @@ class NetworkCreator extends EventEmitter {
 
   generateGethTxFiller (volumes) {
     let txFillerService = {
-      image: 'vergauwennico/livepeer-testnet:txfiller',
+      image: 'livepeer/testnet-services:txfiller',
       depends_on: this.hasGeth ? ['geth'] : [],
       networks: {
         testnet: {

--- a/src/networkcreator.js
+++ b/src/networkcreator.js
@@ -11,7 +11,7 @@ const composefile = require('composefile')
 const { timesLimit, each, eachLimit } = require('async')
 const log = require('debug')('livepeer:test-harness:network')
 const Pool = require('threads').Pool
-const { getNames, spread, needToCreateGeth } = require('./utils/helpers')
+const { getNames, spread, needToCreateGeth, needToCreateGethFaucet, needToCreateGethTxFiller } = require('./utils/helpers')
 const { PROJECT_ID, NODE_TYPES } = require('./constants')
 const YAML = require('yaml')
 const mConfigs = require('./configs')
@@ -554,6 +554,8 @@ class NetworkCreator extends EventEmitter {
     } else {
       this.hasGeth = true
     }
+    output.gethFaucet = this.generateGethFaucet(volumes)
+    output.gethTxFiller = this.generateGethTxFiller(volumes)
     this.hasMetrics = this.config.metrics
     if (this.hasMetrics) {
       // output.prometheus = this.generatePrometheusService(outputFolder, volumes, configs)
@@ -1062,6 +1064,60 @@ class NetworkCreator extends EventEmitter {
     return needToCreateGeth(this.config) ? gethService : undefined
   }
 
+  generateGethFaucet (volumes) {
+    let faucetService = {
+      image: 'vergauwennico/livepeer-testnet:faucet',
+      ports: [
+        '3333:8080'
+      ],
+      depends_on: this.hasGeth ? ['geth'] : [],
+      networks: {
+        testnet: {
+          aliases: [`faucet`]
+        }
+      },
+      command: [
+        '-network',
+        '54321',
+        '-provider',
+        'http://geth:8545',
+        '-keystore',
+        'keystore',
+        '-address',
+        '0161e041aad467a890839d5b08b138c1e6373072'
+      ],
+      restart: 'unless-stopped',
+    }
+
+    return needToCreateGethFaucet(this.config) ? faucetService : undefined
+  }
+
+  generateGethTxFiller (volumes) {
+    let txFillerService = {
+      image: 'vergauwennico/livepeer-testnet:txfiller',
+      depends_on: this.hasGeth ? ['geth'] : [],
+      networks: {
+        testnet: {
+          aliases: ['tx-filler']
+        }
+      },
+      command: [
+        '-senderAddr',
+        '0161e041aad467a890839d5b08b138c1e6373072',
+        '-chainID',
+        '54321',
+        '-provider',
+        'http://geth:8545',
+        '-keystoreDir',
+        'keystore',
+        '-password',
+        'password.txt'
+      ],
+      restart: 'unless-stopped'
+    }
+    return needToCreateGethTxFiller(this.config) ? txFillerService : undefined
+  }
+
   getNodeOptions (gname, nodes, i) {
     const output = []
     const userFlags = nodes.flags
@@ -1206,7 +1262,7 @@ class NetworkCreator extends EventEmitter {
   */
 }
 
-let usedPorts = [8545, 8546, 30303, 8080, 3000, 3001, 9090]
+let usedPorts = [8545, 8546, 30303, 8080, 3000, 3001, 3333, 9090]
 function getRandomPort (origin) {
   // TODO, ugh, fix this terrible recursive logic, use an incrementer like a gentleman
   let port = origin + Math.floor(Math.random() * 999)

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -160,6 +160,18 @@ function needToCreateGeth (config) {
     return false
 }
 
+function needToCreateGethFaucet(config) {
+    if (needToCreateGeth(config) ) {
+      return (config.blockchain||{}).faucet
+    }
+}
+
+function needToCreateGethTxFiller(config) {
+  if (needToCreateGeth(config )) {
+    return (config.blockchain||{}).txFiller
+  }
+}
+
 function parseComposeAndGetAddresses (configName) {
   let parsedCompose = null
   try {
@@ -285,5 +297,5 @@ async function _loadLocalDockerImageToSwarm(swarm, managerName) {
 
 module.exports = {contractId, functionSig, functionEncodedABI, remotelyExec, fundAccount, fundRemoteAccount,
   getNames, spread, wait, parseComposeAndGetAddresses,
-  getIds, getConstrain, needToCreateGeth, saveLocalDockerImage, loadLocalDockerImageToSwarm, pushDockerImageToSwarmRegistry
+  getIds, getConstrain, needToCreateGeth, needToCreateGethFaucet, needToCreateGethTxFiller, saveLocalDockerImage, loadLocalDockerImageToSwarm, pushDockerImageToSwarmRegistry
 }


### PR DESCRIPTION
This PR adds an [ETH faucet](https://github.com/kyriediculous/simple-eth-faucet) and [transaction filler](https://github.com/kyriediculous/eth-tx-filler) to the internally ran private geth network when the test-harness is started in on-chain mode. 

Images for these services can be found on dockerhub: https://cloud.docker.com/u/vergauwennico/repository/docker/vergauwennico/livepeer-testnet

**Changes**
- Added `networkcreator.js/generateGethFaucet()`
- Added `networkcreator.js/generateGethTxFiller()`
- Added `needToCreateGethFaucet()` and `needToCreateGethTxFiller()` helpers to determine whether these services should be added to the generated docker-compose
- Now prints geth and faucet endpoints to console after starting test harness in on-chain mode
- config now supports `blockchain.faucet:bool` and `blockchain.txFiller:bool options` (can be objects in the future to add config support for these services).

Fixes #70
Fixes #77 