### PR TITLE
new controller address for updated geth image

### DIFF
--- a/examples/100streams.js
+++ b/examples/100streams.js
@@ -19,7 +19,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
 
   machines: {

--- a/examples/10broadcasters.js
+++ b/examples/10broadcasters.js
@@ -35,7 +35,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     num: 4,

--- a/examples/demo5.js
+++ b/examples/demo5.js
@@ -20,7 +20,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     zone: 'us-east1-b',

--- a/examples/gce.js
+++ b/examples/gce.js
@@ -20,7 +20,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     num: 3,

--- a/examples/index.js
+++ b/examples/index.js
@@ -33,7 +33,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     num: 5,

--- a/examples/local.js
+++ b/examples/local.js
@@ -18,7 +18,7 @@ th.run({
     // keep these to run a private testnet.
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982' //pm
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF' //pm
   },
   nodes: {
     streamers: {

--- a/examples/multigroups.js
+++ b/examples/multigroups.js
@@ -18,7 +18,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     // total VM instances number

--- a/examples/multiregion.js
+++ b/examples/multiregion.js
@@ -16,7 +16,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     // total VM instances number

--- a/examples/week5streams.js
+++ b/examples/week5streams.js
@@ -26,7 +26,7 @@ th.run({
   blockchain: {
     name: 'lpTestNet',
     networkId: 54321,
-    controllerAddress: '0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982',
+    controllerAddress: '0x77A0865438f2EfD65667362D4a8937537CA7a5EF',
   },
   machines: {
     // total VM instances number


### PR DESCRIPTION
The geth image we're using has been upgraded to geth v1.9.0, normally this wouldn't change the controller contract address.

Since [that particular PR](https://github.com/livepeer/docker-livepeer/pull/10) also changes the deployer address for the smart contracts (by adjusting the $GETH_MINING_ACCOUNT value) though, that controller address changes. 

> In Dockerfile changed GETH_MINING_ACCOUNT env variable to be the correct sealer (0x0161e0...) as defined in genesis.json extradata field, 0x87da6... is a funded genesis account but not the sealer.

The `livepeer/geth-with-livepeer-protocol:pm` docker image used on the current master branch has already been updated to include this change. 

If you still wish to use the old image and controller address you can do so with `livepeer/geth-with-livepeer-protocol:pm-v1.7.3` and `0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982`

