### PR TITLE
Add config fields for txFiller minGasPrice and maxGasPrice

### DIFF
--- a/src/networkcreator.js
+++ b/src/networkcreator.js
@@ -1117,6 +1117,14 @@ class NetworkCreator extends EventEmitter {
       ],
       restart: 'unless-stopped'
     }
+
+    if ((this.config.blockchain||{}).minGasPrice) {
+      txFillerService.command.push('-minGasPrice', this.config.blockchain.minGasPrice)
+    }
+    if ((this.config.blockchain||{}).maxGasPrice) {
+      txFillerService.command.push('-maxGasPrice', this.config.blockchain.maxGasPrice)
+    }
+
     return needToCreateGethTxFiller(this.config) ? txFillerService : undefined
   }
 


### PR DESCRIPTION
This PR adds the `minGasPrice` and `maxGasPrice` fields in the `blockchain` object of a config file. The test-harness will parse these fields if they are set and pass the values into the transaction filler service.